### PR TITLE
カレンダー表示機能を追加

### DIFF
--- a/python/calendar.py
+++ b/python/calendar.py
@@ -1,0 +1,98 @@
+import argparse
+import datetime
+
+MONTH_NAME = {1: "January", 2: "February", 3: "March", 4: "April", 5: "May", 6: "June", 7: "July", 8: "August", 9: "September", 10: "October", 11: "November", 12: "December"}
+WEEK_NAME = ["月", "火", "水", "木", "金", "土", "日"]
+DAY_LIST = [" 1"," 2"," 3"," 4"," 5"," 6"," 7"," 8"," 9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31"]
+
+def get_options():
+    """
+    コマンドライン引数を解析する関数
+    Returns:
+        argparse.Namespace: コマンドライン引数
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", type=int, default=datetime.date.today().month)
+    parser.add_argument("-y", type=int, default=datetime.date.today().year)
+    args = parser.parse_args()
+    return args
+
+def get_days_in_month(year, month):
+    """
+    指定された年と月の日数を返す関数
+    Args:
+        year (int): 年
+        month (int): 月
+    Returns:
+        int: 指定された年と月の日数 
+    """
+
+    next_month      = (month % 12) + 1
+    next_month_year = year + (month == 12)
+
+    first_day_of_next_month = datetime.date(next_month_year, next_month, 1)
+    last_day_of_month = first_day_of_next_month - datetime.timedelta(days=1)
+    
+    return last_day_of_month.day
+
+
+def validate_month(month):
+    """
+    指定された月が有効かどうかを確認する関数
+    Args:
+        month (int): 月
+    Returns:
+        bool: True:有効, False:無効
+    """
+    return 1 <= month <= 12
+    
+def validate_year(year):
+    """
+    指定された年が有効かどうかを確認する関数
+    Args:
+        year (int): 年
+    Returns:
+        bool: True:有効, False:無効
+    """
+    return 1 <= year <= 9999
+
+def print_calendar(month, year):
+    """
+    指定された年と月のカレンダーを表示する関数
+    Args:
+        month (int): 月
+        year (int): 年
+    """
+    if not validate_month(month):
+        return print("有効な月を指定してください（1〜12）")
+    elif not validate_year(year):
+        return print("有効な年を指定してください（1〜9999）")
+
+    first_day = datetime.date(year, month, 1)
+    first_day_weekday = first_day.weekday()
+    
+    days_count = get_days_in_month(year, month)
+    days_list = DAY_LIST[:days_count]
+    
+    first_week_margin = "   " * first_day_weekday
+    first_week_days_count = 7 - first_day_weekday
+    
+    weeks = []
+    weeks.append(first_week_margin + " ".join(days_list[:first_week_days_count]))
+    
+    for week_num in range(1, 6):
+        start_index = first_week_days_count + (week_num - 1) * 7
+        end_index = min(start_index + 7, days_count)
+        
+        if start_index < days_count:
+            week_str = " ".join(days_list[start_index:end_index])
+            weeks.append(week_str)
+    
+    print(f"{MONTH_NAME[month]} {year}")
+    print(f"{' '.join(WEEK_NAME)}")
+    for week in weeks:
+        print(week)
+
+if __name__ == "__main__":
+    args = get_options()
+    print_calendar(args.m, args.y)

--- a/python/calendar.py
+++ b/python/calendar.py
@@ -77,8 +77,7 @@ def print_calendar(month, year):
     
     for day in range(1, days_count + 1):
         # 日付が1桁表示の場合は前にもスペースを追加して揃える
-        date_display += f" {day} " if day < 10 else f"{day} "
-        
+        date_display += f"{str(day).rjust(2)} "
         current_weekday += 1
         
         if current_weekday == 7:

--- a/python/calendar.py
+++ b/python/calendar.py
@@ -3,7 +3,6 @@ import datetime
 
 MONTH_NAME = {1: "January", 2: "February", 3: "March", 4: "April", 5: "May", 6: "June", 7: "July", 8: "August", 9: "September", 10: "October", 11: "November", 12: "December"}
 WEEK_NAME = ["月", "火", "水", "木", "金", "土", "日"]
-DAY_LIST = [" 1"," 2"," 3"," 4"," 5"," 6"," 7"," 8"," 9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31"]
 
 def get_options():
     """
@@ -12,8 +11,9 @@ def get_options():
         argparse.Namespace: コマンドライン引数
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument("-m", type=int, default=datetime.date.today().month)
-    parser.add_argument("-y", type=int, default=datetime.date.today().year)
+    today = datetime.date.today()
+    parser.add_argument("-m", type=int, default=today.month)
+    parser.add_argument("-y", type=int, default=today.year)
     args = parser.parse_args()
     return args
 
@@ -72,26 +72,23 @@ def print_calendar(month, year):
     first_day_weekday = first_day.weekday()
     
     days_count = get_days_in_month(year, month)
-    days_list = DAY_LIST[:days_count]
+    date_display = "   " * first_day_weekday
+    current_weekday = first_day_weekday
     
-    first_week_margin = "   " * first_day_weekday
-    first_week_days_count = 7 - first_day_weekday
-    
-    weeks = []
-    weeks.append(first_week_margin + " ".join(days_list[:first_week_days_count]))
-    
-    for week_num in range(1, 6):
-        start_index = first_week_days_count + (week_num - 1) * 7
-        end_index = min(start_index + 7, days_count)
+    for day in range(1, days_count + 1):
+        # 日付が1桁表示の場合は前にもスペースを追加して揃える
+        date_display += f" {day} " if day < 10 else f"{day} "
         
-        if start_index < days_count:
-            week_str = " ".join(days_list[start_index:end_index])
-            weeks.append(week_str)
-    
+        current_weekday += 1
+        
+        if current_weekday == 7:
+            current_weekday = 0
+            date_display += "\n"
+
     print(f"{MONTH_NAME[month]} {year}")
     print(f"{' '.join(WEEK_NAME)}")
-    for week in weeks:
-        print(week)
+    print(date_display)
+
 
 if __name__ == "__main__":
     args = get_options()


### PR DESCRIPTION
## 課題のリンク

* https://kirara-code.net/HappinessChain/tasks/105?chapterId=38

## やったこと

* mac に入っている cal コマンドと同じ見た目になっている
* 月曜始まりで実装
* calendar モジュール は使わない
* -mオプションで月を指定できるように
* -yオプションで年を指定できるように（追加機能）
* 引数を指定しない場合は、今月・今年のカレンダーが表示される
* -m, -yの引数が不正な月,年の場合はエラーを出すこと

```
MacBook-Air hc_practice % python3 python/calendar.py -m 20
有効な月を指定してください（1〜12）
MacBook-Air hc_practice % python3 python/calendar.py -y 99999
有効な年を指定してください（1〜9999）
```

| オプション未指定| 年,月を指定|
|---|---|
|<img width="329" alt="image" src="https://github.com/user-attachments/assets/2019db51-2fe1-478b-b4a4-0dd5677060ac" />|<img width="423" alt="image" src="https://github.com/user-attachments/assets/df004ace-6a04-49da-9242-4f0968d6fcec" />|

|エラー時|
|---|
|<img width="393" alt="image" src="https://github.com/user-attachments/assets/707abbb3-1c48-4c70-a795-62f0857c3a93" />|


## 動作確認方法

* `python3 python/calendar.py`を実行

 
## その他

* 特になし
